### PR TITLE
Refactor: Require only "content" for files

### DIFF
--- a/dev-schema/file/audio.json
+++ b/dev-schema/file/audio.json
@@ -11,5 +11,5 @@
 			"type": "string"
 		}
 	},
-	"required": ["mimeType", "size", "content"]
+	"required": ["content"]
 }

--- a/dev-schema/file/image.json
+++ b/dev-schema/file/image.json
@@ -11,5 +11,5 @@
 			"type": "string"
 		}
 	},
-	"required": ["mimeType", "size", "content"]
+	"required": ["content"]
 }

--- a/resolved-dev-repository.json
+++ b/resolved-dev-repository.json
@@ -240,7 +240,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					},
 					"issued": {
@@ -275,7 +275,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					}
 				},
@@ -1473,7 +1473,7 @@
 								"type": "string"
 							}
 						},
-						"required": ["mimeType", "size", "content"]
+						"required": ["content"]
 					},
 					"back": {
 						"title": "Back image",
@@ -1494,7 +1494,7 @@
 								"type": "string"
 							}
 						},
-						"required": ["mimeType", "size", "content"]
+						"required": ["content"]
 					},
 					"expires": {
 						"$id": "http://platform.selfkey.org/schema/misc/expiry-date.json",
@@ -1529,7 +1529,7 @@
 										"type": "string"
 									}
 								},
-								"required": ["mimeType", "size", "content"]
+								"required": ["content"]
 							}
 						},
 						"required": ["image"]
@@ -1559,7 +1559,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					}
 				},
@@ -1646,7 +1646,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					},
 					"extra": {
@@ -1674,7 +1674,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					}
 				},
@@ -2902,7 +2902,7 @@
 								"type": "string"
 							}
 						},
-						"required": ["mimeType", "size", "content"]
+						"required": ["content"]
 					},
 					"back": {
 						"title": "Back image",
@@ -2923,7 +2923,7 @@
 								"type": "string"
 							}
 						},
-						"required": ["mimeType", "size", "content"]
+						"required": ["content"]
 					},
 					"issued": {
 						"$id": "http://platform.selfkey.org/schema/misc/issue-date.json",
@@ -2965,7 +2965,7 @@
 										"type": "string"
 									}
 								},
-								"required": ["mimeType", "size", "content"]
+								"required": ["content"]
 							}
 						},
 						"required": ["image"]
@@ -2995,7 +2995,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					}
 				},
@@ -3611,7 +3611,7 @@
 								"type": "string"
 							}
 						},
-						"required": ["mimeType", "size", "content"]
+						"required": ["content"]
 					},
 					"issued": {
 						"$id": "http://platform.selfkey.org/schema/misc/issue-date.json",
@@ -3653,7 +3653,7 @@
 										"type": "string"
 									}
 								},
-								"required": ["mimeType", "size", "content"]
+								"required": ["content"]
 							}
 						},
 						"required": ["image"]
@@ -3683,7 +3683,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					}
 				},
@@ -3847,7 +3847,7 @@
 								"type": "string"
 							}
 						},
-						"required": ["mimeType", "size", "content"]
+						"required": ["content"]
 					},
 					"issued": {
 						"$id": "http://platform.selfkey.org/schema/misc/issue-date.json",
@@ -3881,7 +3881,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					}
 				},
@@ -3969,7 +3969,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					},
 					"issued": {
@@ -4004,7 +4004,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					}
 				},
@@ -4062,7 +4062,7 @@
 							"type": "string"
 						}
 					},
-					"required": ["mimeType", "size", "content"]
+					"required": ["content"]
 				},
 				"minItems": 1,
 				"noFill": true
@@ -4219,7 +4219,7 @@
 								"type": "string"
 							}
 						},
-						"required": ["mimeType", "size", "content"]
+						"required": ["content"]
 					},
 					"issued": {
 						"$id": "http://platform.selfkey.org/schema/misc/issue-date.json",
@@ -4253,7 +4253,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					}
 				},
@@ -4321,7 +4321,7 @@
 								"type": "string"
 							}
 						},
-						"required": ["mimeType", "size", "content"]
+						"required": ["content"]
 					},
 					"company_name": {
 						"title": "Company Name",
@@ -4363,7 +4363,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					}
 				},
@@ -4415,7 +4415,7 @@
 							"type": "string"
 						}
 					},
-					"required": ["mimeType", "size", "content"]
+					"required": ["content"]
 				},
 				"minItems": 1,
 				"noFill": true
@@ -4499,7 +4499,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					},
 					"extra": {
@@ -4527,7 +4527,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					}
 				},
@@ -4592,7 +4592,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					},
 					"issued": {
@@ -4627,7 +4627,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					}
 				},
@@ -4679,7 +4679,7 @@
 							"type": "string"
 						}
 					},
-					"required": ["mimeType", "size", "content"]
+					"required": ["content"]
 				},
 				"minItems": 1,
 				"noFill": true
@@ -4730,7 +4730,7 @@
 							"type": "string"
 						}
 					},
-					"required": ["mimeType", "size", "content"]
+					"required": ["content"]
 				},
 				"minItems": 1,
 				"noFill": true

--- a/resolved-repository.json
+++ b/resolved-repository.json
@@ -235,7 +235,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					},
 					"issued": {
@@ -270,7 +270,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					}
 				},
@@ -1468,7 +1468,7 @@
 								"type": "string"
 							}
 						},
-						"required": ["mimeType", "size", "content"]
+						"required": ["content"]
 					},
 					"back": {
 						"title": "Back image",
@@ -1489,7 +1489,7 @@
 								"type": "string"
 							}
 						},
-						"required": ["mimeType", "size", "content"]
+						"required": ["content"]
 					},
 					"expires": {
 						"$id": "http://platform.selfkey.org/schema/misc/expiry-date.json",
@@ -1524,7 +1524,7 @@
 										"type": "string"
 									}
 								},
-								"required": ["mimeType", "size", "content"]
+								"required": ["content"]
 							}
 						},
 						"required": ["image"]
@@ -1554,7 +1554,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					}
 				},
@@ -1641,7 +1641,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					},
 					"extra": {
@@ -1669,7 +1669,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					}
 				},
@@ -2897,7 +2897,7 @@
 								"type": "string"
 							}
 						},
-						"required": ["mimeType", "size", "content"]
+						"required": ["content"]
 					},
 					"back": {
 						"title": "Back image",
@@ -2918,7 +2918,7 @@
 								"type": "string"
 							}
 						},
-						"required": ["mimeType", "size", "content"]
+						"required": ["content"]
 					},
 					"issued": {
 						"$id": "http://platform.selfkey.org/schema/misc/issue-date.json",
@@ -2960,7 +2960,7 @@
 										"type": "string"
 									}
 								},
-								"required": ["mimeType", "size", "content"]
+								"required": ["content"]
 							}
 						},
 						"required": ["image"]
@@ -2990,7 +2990,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					}
 				},
@@ -3606,7 +3606,7 @@
 								"type": "string"
 							}
 						},
-						"required": ["mimeType", "size", "content"]
+						"required": ["content"]
 					},
 					"issued": {
 						"$id": "http://platform.selfkey.org/schema/misc/issue-date.json",
@@ -3648,7 +3648,7 @@
 										"type": "string"
 									}
 								},
-								"required": ["mimeType", "size", "content"]
+								"required": ["content"]
 							}
 						},
 						"required": ["image"]
@@ -3678,7 +3678,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					}
 				},
@@ -3842,7 +3842,7 @@
 								"type": "string"
 							}
 						},
-						"required": ["mimeType", "size", "content"]
+						"required": ["content"]
 					},
 					"issued": {
 						"$id": "http://platform.selfkey.org/schema/misc/issue-date.json",
@@ -3876,7 +3876,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					}
 				},
@@ -3964,7 +3964,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					},
 					"issued": {
@@ -3999,7 +3999,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					}
 				},
@@ -4057,7 +4057,7 @@
 							"type": "string"
 						}
 					},
-					"required": ["mimeType", "size", "content"]
+					"required": ["content"]
 				},
 				"minItems": 1,
 				"noFill": true
@@ -4214,7 +4214,7 @@
 								"type": "string"
 							}
 						},
-						"required": ["mimeType", "size", "content"]
+						"required": ["content"]
 					},
 					"issued": {
 						"$id": "http://platform.selfkey.org/schema/misc/issue-date.json",
@@ -4248,7 +4248,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					}
 				},
@@ -4316,7 +4316,7 @@
 								"type": "string"
 							}
 						},
-						"required": ["mimeType", "size", "content"]
+						"required": ["content"]
 					},
 					"company_name": {
 						"title": "Company Name",
@@ -4358,7 +4358,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					}
 				},
@@ -4410,7 +4410,7 @@
 							"type": "string"
 						}
 					},
-					"required": ["mimeType", "size", "content"]
+					"required": ["content"]
 				},
 				"minItems": 1,
 				"noFill": true
@@ -4494,7 +4494,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					},
 					"extra": {
@@ -4522,7 +4522,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					}
 				},
@@ -4587,7 +4587,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					},
 					"issued": {
@@ -4622,7 +4622,7 @@
 									"type": "string"
 								}
 							},
-							"required": ["mimeType", "size", "content"]
+							"required": ["content"]
 						}
 					}
 				},
@@ -4674,7 +4674,7 @@
 							"type": "string"
 						}
 					},
-					"required": ["mimeType", "size", "content"]
+					"required": ["content"]
 				},
 				"minItems": 1,
 				"noFill": true
@@ -4725,7 +4725,7 @@
 							"type": "string"
 						}
 					},
-					"required": ["mimeType", "size", "content"]
+					"required": ["content"]
 				},
 				"minItems": 1,
 				"noFill": true

--- a/schema/file/audio.json
+++ b/schema/file/audio.json
@@ -11,5 +11,5 @@
 			"type": "string"
 		}
 	},
-	"required": ["mimeType", "size", "content"]
+	"required": ["content"]
 }

--- a/schema/file/image.json
+++ b/schema/file/image.json
@@ -11,5 +11,5 @@
 			"type": "string"
 		}
 	},
-	"required": ["mimeType", "size", "content"]
+	"required": ["content"]
 }


### PR DESCRIPTION
Previously image attribute required client to send content type and
the size of the file along with the content. This was intended to
work with base64 format. With current integrations file id is used
so it's not necessary for client to send these fields because they
can be check on API side.